### PR TITLE
Added xfoil_update_current_airfoil to copy buffer to current airfoil.

### DIFF
--- a/examples/python_example1.py
+++ b/examples/python_example1.py
@@ -110,7 +110,7 @@ if __name__ == "__main__":
     sys.exit(1)
   x_noflap, z_noflap, stat = xiw.xfoil_get_current_airfoil(xdg, npointnew)
   if (stat != 0):
-    print("Error getting airfoil: xfoil_smooth_paneling must be called first.")
+    print("Error getting airfoil: xfoil_smooth_paneling or xfoil_update_current_airfoil must be called first.")
     sys.exit(1)
   plot_oldnew(x, z, x_noflap, z_noflap)
 
@@ -130,7 +130,7 @@ if __name__ == "__main__":
     print("Alpha: {:.4f}, Cl: {:.4f}, Cd: {:.4f}, Cm: {:.4f}"\
           .format(alpha, cl, cd, cm))
   elif stat == 1:
-    print("Error running xfoil: xfoil_smooth_paneling must be called first.")
+    print("Error running xfoil: xfoil_smooth_paneling or xfoil_update_current_airfoil must be called first.")
     sys.exit(1)
 
   # Get surface cp, cf, transition location, ampl. ratio
@@ -155,7 +155,7 @@ if __name__ == "__main__":
     sys.exit(1)
   x_withflap, z_withflap, stat = xiw.xfoil_get_current_airfoil(xdg, npointnew)
   if (stat != 0):
-    print("Error getting airfoil: xfoil_smooth_paneling must be called first.")
+    print("Error getting airfoil: xfoil_smooth_paneling or xfoil_update_current_airfoil must be called first.")
     sys.exit(1)
   plot_oldnew(x, z, x_withflap, z_withflap)
 
@@ -169,7 +169,7 @@ if __name__ == "__main__":
     print("Alpha: {:.4f}, Cl: {:.4f}, Cd: {:.4f}, Cm: {:.4f}"\
           .format(alpha, cl, cd, cm))
   elif stat == 1:
-    print("Error running xfoil: xfoil_smooth_paneling must be called first.")
+    print("Error running xfoil: xfoil_smooth_paneling or xfoil_update_current_airfoil must be called first.")
     sys.exit(1)
 
   # Get surface cp, cf, transition location, ampl. ratio

--- a/examples/python_example3_parallel.py
+++ b/examples/python_example3_parallel.py
@@ -65,7 +65,7 @@ def analyze_all_re(camber, xcamber, thick, re, mach):
                     print("Warning: convergence failed for alpha {:.1f}." \
                           .format(res['alpha'][i]))
             else:
-                print("Error: xfoil_smooth_paneling must be called first.")
+                print("Error: xfoil_smooth_paneling or xfoil_update_current_airfoil must be called first.")
                 sys.exit(1)
         results.append(res)
 
@@ -103,7 +103,7 @@ def analyze_one_re(camber, xcamber, thick, re, mach):
                 print("Warning: convergence failed for alpha {:.1f}." \
                       .format(res['alpha'][i]))
         else:
-            print("Error: xfoil_smooth_paneling must be called first.")
+            print("Error: xfoil_smooth_paneling or xfoil_update_current_airfoil must be called first.")
             sys.exit(1)
 
     return res

--- a/python/libxfoil.i
+++ b/python/libxfoil.i
@@ -186,6 +186,7 @@ extern void xfoil_get_buffer_airfoil(xfoil_data_group *xdg, double *xout,
 extern void xfoil_get_current_airfoil(xfoil_data_group *xdg, double *xout,
                                       double *zout, int *npoint, int *stat);
 extern void xfoil_smooth_paneling(xfoil_data_group *xdg, int *stat);
+extern void xfoil_update_current_airfoil(xfoil_data_group *xdg, int *stat);
 extern void xfoil_apply_flap_deflection(xfoil_data_group *xdg,
                                         double *xflap, double *zflap,
                                         int *z_flap_spec, double *degrees,

--- a/python/libxfoil_wrap.py
+++ b/python/libxfoil_wrap.py
@@ -118,6 +118,17 @@ def xfoil_smooth_paneling(xdg):
 
   return stat
 
+def xfoil_update_current_airfoil(xdg):
+  stat_p = xi.new_intp()
+  
+  xi.xfoil_update_current_airfoil(xdg, stat_p)
+  stat = xi.intp_value(stat_p)
+  
+  xi.delete_intp(stat_p)
+  
+  return stat
+  
+
 def xfoil_apply_flap_deflection(xdg, xflap, zflap, z_flap_spec, degrees):
 
   xflap_p = xi.copy_doublep(xflap)

--- a/src/libxfoil.f90
+++ b/src/libxfoil.f90
@@ -274,7 +274,7 @@ end subroutine xfoil_get_buffer_airfoil
 !
 ! Returns current (not buffer) airfoil coordinates from Xfoil
 ! stat: 0 for success, 1 if current airfoil is not available (call
-!   xfoil_smooth_paneling first)
+!   xfoil_smooth_paneling or xfoil_update_current_airfoil first)
 !
 !=============================================================================80
 subroutine xfoil_get_current_airfoil(xdg, xout, zout, npoint, stat)            &
@@ -330,6 +330,28 @@ subroutine xfoil_smooth_paneling(xdg, stat)                                    &
   call PANGEN(xdg%xfd, .NOT. xdg%xfd%SILENT_MODE)
 
 end subroutine xfoil_smooth_paneling
+
+!=============================================================================80
+!
+! Set the current airfoil directly from the buffer airfoil
+! stat: 0 for success, 1 for failure (xfoil_set_buffer_airfoil not called yet)
+!
+!=============================================================================80
+subroutine xfoil_update_current_airfoil(xdg, stat)                             &
+           bind(c, name="xfoil_update_current_airfoil")
+      
+  type(xfoil_data_group), intent(inout) :: xdg
+  integer(c_int), intent(out) :: stat
+
+  stat = 0
+  if (xdg%xfd%NB == 0) then
+    stat = 1
+    return
+  end if
+
+  call ABCOPY(xdg%xfd, .NOT. xdg%xfd%SILENT_MODE)
+
+end subroutine xfoil_update_current_airfoil
 
 !=============================================================================80
 !
@@ -406,7 +428,7 @@ end subroutine xfoil_modify_tegap
 !
 ! Gets thickness and camber information for the current (not buffer) airfoil
 ! stat: 0 for success, 1 if current airfoil is not available (call
-!   xfoil_smooth_paneling first)
+!   xfoil_smooth_paneling or xfoil_update_current_airfoil first)
 !
 !=============================================================================80
 subroutine xfoil_geometry_info(xdg, maxt, xmaxt, maxc, xmaxc, stat)            &
@@ -482,7 +504,7 @@ end subroutine xfoil_reinitialize_bl
 ! Assumes airfoil geometry, reynolds number, and mach number have already been
 ! set in Xfoil.
 ! stat: 0 for success, 1 if current airfoil is not available (call
-!   xfoil_smooth_paneling first)
+!   xfoil_smooth_paneling or xfoil_update_current_airfoil first)
 !
 !=============================================================================80
 subroutine xfoil_specal(xdg, alpha_spec, alpha, lift, drag, moment, converged, &
@@ -538,7 +560,7 @@ end subroutine xfoil_specal
 ! Assumes airfoil geometry, reynolds number, and mach number have already been
 ! set in Xfoil.
 ! stat: 0 for success, 1 if current airfoil is not available (call
-!   xfoil_smooth_paneling first)
+!   xfoil_smooth_paneling or xfoil_update_current_airfoil first)
 !
 !=============================================================================80
 subroutine xfoil_speccl(xdg, cl_spec, alpha, lift, drag, moment, converged,    &

--- a/src/libxfoil.h
+++ b/src/libxfoil.h
@@ -184,6 +184,7 @@ extern void xfoil_get_current_airfoil(const xfoil_data_group *xdg,
                                       double xout[], double zout[],
                                       const int *npoint, int *stat);
 extern void xfoil_smooth_paneling(xfoil_data_group *xdg, int *stat);
+extern void xfoil_update_current_airfoil(const xfoil_data_group *xdg, int *stat);
 extern void xfoil_apply_flap_deflection(xfoil_data_group *xdg,
                                         const double *xflap,
                                         const double *zflap,


### PR DESCRIPTION
Similar to the `PCOP` command in the xfoil command line application. This allows to modify geometry/paneling of the airfoil outside of xfoil.